### PR TITLE
stop warnings spamming the log

### DIFF
--- a/topline.php
+++ b/topline.php
@@ -84,6 +84,7 @@ class topline extends rcube_plugin
         $identity = $user->get_identity();
         $content="";
         $mpty=1;
+        if(!is_array($what)) $what = array($what);
         foreach ($what as &$value) {
             switch ($value) {
                 case 'username':


### PR DESCRIPTION
It keeps hitting the log, if $what is a string and not an array -> make it an array then...
